### PR TITLE
Fixing some things

### DIFF
--- a/mp/admin_menu/function/basic.gsc
+++ b/mp/admin_menu/function/basic.gsc
@@ -420,7 +420,7 @@ KillPlayer(player)
 KickPlayer(player)
 {
     iPrintLn(player.name + " Was kicked.");
-    executeCommand("kickClient " + player.name);
+    kick(player getEntityNumber());
 }
 
 BanPlayer(player)

--- a/mp/admin_menu/structure.gsc
+++ b/mp/admin_menu/structure.gsc
@@ -132,7 +132,7 @@ new_menu( menu ) {
     self endon( "close_menu" );
 
     if( self get_menu() == "Session Players" && isdefined( menu ) ) {
-        player = level.players[ ( self get_cursor() + 1 ) ];
+        player = level.players[ ( self get_cursor()) ];
         self.selected_player = player;
     }
 


### PR DESCRIPTION
I fixed the kick option in Session players not kicking the proper person, and kicking either the host/person operating the menu.

I also fixed the issue where when you choose a player in Session Player, it doesn't match the player you see in the top left.

This causes issues when using any of the options as it applies to the person you are on and not the player you chose in the "Session Players" menu.